### PR TITLE
Fixes for holberton.h

### DIFF
--- a/holberton.h
+++ b/holberton.h
@@ -1,28 +1,25 @@
-#ifndef HOLBERTON_H
-#define HOLBERTON_H
+#ifndef _HOLBERTON_H_
+#define _HOLBERTON_H_
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdarg.h>
 int _printf(const char *format, ...);
 int _putchar(char c);
-int _count_tokens(char *format);
 int _print(char *format);
 char *_itoa(int n);
 int _strlen(char *str);
-int _is_valid_token(char *format, int current_pos);
-
 
 /**
- *struct token - holds information about tokens in format string
- *@pos: start index position of token in format string
- *@len: length of token chars (always 2 or greater)
- *@conversion_specifier: char that tells us datatype of arg
- *@length_modifier: ignore for now-- may use later in advanced tasks
- *@flag: ignore for now-- may use later in advanced tasks
- *@min_width: ignore for now-- may use later in advanced tasks
- *@precision: ignore for now-- may use later in advanced tasks
+ * struct token - holds information about tokens in format string
+ * @pos: start index position of token in format string
+ * @len: length of token chars (always 2 or greater)
+ * @conversion_specifier: char that tells us datatype of arg
+ * @length_modifier: ignore for now-- may use later in advanced tasks
+ * @flag: ignore for now-- may use later in advanced tasks
+ * @min_width: ignore for now-- may use later in advanced tasks
+ * @precision: ignore for now-- may use later in advanced tasks
  *
- *Description: %[flag][min width][precision][length modifier][conversion specifier]
+ * Description: %[flag][min width][precision][length modifier][conversion specifier]
  */
 struct token
 {
@@ -34,74 +31,45 @@ struct token
 	int min_width;
 	int precision;
 };
-/*create datatype token_t */
+/* create datatype token_t */
 typedef struct token token_t;
+
+/* prototypes for type-specific print functions */
+int print_char(token_t tok, va_list args);
+int print_string(token_t tok, va_list args);
+int print_integer(token_t tok, va_list args);
+int print_binary(token_t tok, va_list args);
+int print_octal(token_t tok, va_list args);
+int print_hex(token_t tok, va_list args);
+int print_reverse(token_t tok, va_list args);
+int print_rot13(token_t tok, va_list args);
+
 /**
- *struct format - maps conversion_specifier char to correct print_fn
- *@conversion_specifier: valid conversion_specifier char
- *@print_fn: pointer to function to handle type-specific printing
+ * struct format - maps conversion_specifier char to correct print_fn
+ * @conversion_specifier: valid conversion_specifier char
+ * @print_fn: pointer to function to handle type-specific printing
  *
- *Description: used to get print_fn for valid conversion_specifier
+ * Description: used to get print_fn for valid conversion_specifier
  */
 struct format
 {
 	char conversion_specifier;
-	int(*print_fn)(token_t);
+	int(*print_fn)(token_t, va_list);
 };
 /*create datatype format_t */
 typedef struct format format_t;
-/**
- *struct fmt - array of format_t linking conversion_specifier to print_fn
- */
-struct format_t fmt[] = {
+
+/* create a static array of format_t for all valid chars */
+static format_t fmt[] = {
 	{'c', print_char},
 	{'s', print_string},
-	{'d', print_int}
-};/**
-   *struct token - holds information about tokens in format string
-   *@pos: start index position of token in format string
-   *@len: length of token chars (always 2 or greater)
-   *@conversion_specifier: char that tells us datatype of arg
-   *@length_modifier: ignore for now-- may use later in advanced tasks
-   *@flag: ignore for now-- may use later in advanced tasks
-   *@min_width: ignore for now-- may use later in advanced tasks
-   *@precision: ignore for now-- may use later in advanced tasks
-   *
-   *Description: %[flag][min width][precision][length modifier][conversion specifier]
-   */
-struct token
-{
-	int pos;
-	int len;
-	char conversion_specifier;
-	char length_modifier;
-	char flag;
-	int min_width;
-	int precision;
-};
-/*create datatype token_t */
-typedef struct token token_t;
-/**
- *struct format - maps conversion_specifier char to correct print_fn
- *@conversion_specifier: valid conversion_specifier char
- *@print_fn: pointer to function to handle type-specific printing
- *
- *Description: used to get print_fn for valid conversion_specifier
- */
-struct format
-{
-	char conversion_specifier;
-	int(*print_fn)(token_t);
-};
-/*create datatype format_t */
-typedef struct format format_t;
-/**
- *struct fmt - array of format_t linking conversion_specifier to print_fn
- */
-struct format_t fmt[] = {
-	{'c', print_char},
-	{'s', print_string},
-	{'d', print_int}
+	{'d', print_integer},
+	{'i', print_integer},
+	{'b', print_binary},
+	{'o', print_octal},
+	{'x', print_hex},
+	{'r', print_reverse},
+	{'R', print_rot13}
 };
 
 #endif


### PR DESCRIPTION
- Added print_<type> prototypes
- Removed unnecessary prototypes
- Changed struct fmt[] to static variable
- Added additional format_t values to fmt[]